### PR TITLE
feat!: use nla-blacklight_common

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,11 +87,9 @@ gem "blacklight-locale_picker"
 gem "zk", "~> 1.10"
 gem "nokogiri", ">= 1.13.9"
 
-gem "blacklight-solrcloud-repository", git: "https://github.com/nla/blacklight-solrcloud-repository", branch: "main"
-gem "catalogue-patrons", git: "https://github.com/nla/catalogue-patrons", branch: "main"
+gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "main"
 # For local development, comment out above ⤴️ and uncomment below ⤵️
-# gem "blacklight-solrcloud-repository", path: "../blacklight-solrcloud-repository"
-# gem "catalogue-patrons", path: "../catalogue-patrons"
+# gem "nla-blacklight_common", path: "../nla-blacklight_common"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,9 @@
 GIT
-  remote: https://github.com/nla/blacklight-solrcloud-repository
-  revision: 631f07f880099d6bf90d1b53479297e12fee75f0
+  remote: https://github.com/nla/nla-blacklight_common
+  revision: 486c6c1d13f811c5ea8139c57bd6cf1136920340
   branch: main
   specs:
-    blacklight-solrcloud-repository (0.2.3)
-      blacklight (~> 7.30)
-      rsolr
-      zk (~> 1.10)
-
-GIT
-  remote: https://github.com/nla/catalogue-patrons
-  revision: 07ebdb173e298c5d981da5903b6f8773a5361083
-  branch: main
-  specs:
-    catalogue-patrons (3.2.0)
+    nla-blacklight_common (0.1.0)
       activerecord-session_store (~> 2.0)
       annotaterb
       brakeman
@@ -26,7 +16,9 @@ GIT
       omniauth-keycloak (~> 1.4)
       omniauth-rails_csrf_protection (~> 1.0)
       rails (~> 7.0.4)
+      rsolr
       rufus-scheduler (~> 3.8)
+      zk (~> 1.10)
 
 GEM
   remote: https://rubygems.org/
@@ -605,14 +597,12 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   blacklight-locale_picker
-  blacklight-solrcloud-repository!
   blacklight_range_limit (~> 8.2)
   bootsnap
   bootstrap (~> 4.0)
   brakeman
   bundler-audit
   capybara
-  catalogue-patrons!
   database_cleaner-active_record
   debug
   dotenv-rails
@@ -625,6 +615,7 @@ DEPENDENCIES
   jquery-rails
   lograge
   mysql2 (~> 0.5)
+  nla-blacklight_common!
   nokogiri (>= 1.13.9)
   puma (~> 6.0)
   rails (~> 7.0.4)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -65,7 +65,10 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
     config.add_show_tools_partial(:citation)
 
-    # config.add_nav_action(:bookmark, partial: "blacklight/nav/bookmark", if: :render_bookmarks_control?)
+    config.add_nav_action(:new_search, partial: "shared/nav/new_search")
+    config.add_nav_action(:catalogue, partial: "shared/nav/catalogue")
+    config.add_nav_action(:eresources, partial: "shared/nav/eresources")
+    config.add_nav_action(:finding_aids, partial: "shared/nav/finding_aids")
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -1,16 +1,4 @@
 <ul class="navbar-nav">
-  <li class="nav-item">
-    <%= link_to t('blacklight.header_links.search'), '/', class: 'nav-link' %>
-  </li>
-  <li class="nav-item">
-    <%= link_to t('blacklight.header_links.catalogue'), '/catalog', class: 'nav-link' %>
-  </li>
-  <li class="nav-item">
-    <%= link_to t('blacklight.header_links.eresources'), 'https://www.nla.gov.au/eresources', class: 'nav-link' %>
-  </li>
-  <li class="nav-item">
-    <%= link_to t('blacklight.header_links.finding_aids'), '/finding-aids', class: 'nav-link' %>
-  </li>
   <%= render_nav_actions do |config, action|%>
     <li class="nav-item"><%= action %></li>
   <% end %>

--- a/app/views/shared/nav/_catalogue.html.erb
+++ b/app/views/shared/nav/_catalogue.html.erb
@@ -1,0 +1,1 @@
+<%= link_to t("blacklight.header_links.catalogue"), "/catalog", class: "nav-link" %>

--- a/app/views/shared/nav/_eresources.html.erb
+++ b/app/views/shared/nav/_eresources.html.erb
@@ -1,0 +1,1 @@
+<%= link_to t("blacklight.header_links.eresources"), "https://www.nla.gov.au/eresources", class: "nav-link" %>

--- a/app/views/shared/nav/_finding_aids.html.erb
+++ b/app/views/shared/nav/_finding_aids.html.erb
@@ -1,0 +1,1 @@
+<%= link_to t("blacklight.header_links.finding_aids"), root_path, class: "nav-link" %>

--- a/app/views/shared/nav/_new_search.html.erb
+++ b/app/views/shared/nav/_new_search.html.erb
@@ -1,0 +1,1 @@
+<%= link_to t("blacklight.header_links.search"), "/", class: "nav-link" %>


### PR DESCRIPTION
`catalogue-patrons` and `blacklight-solrcloud-repository` have been combined into a single Rails engine named `nla-blacklight_common`. This was done to facilitate the upgrade to Blacklight 8, since `blacklight-solrcloud-repository` would've had to be redeveloped as a Rails engine anyway.

This change removes the old dependencies for `nla-blacklight_common`.