### PR TITLE
fix: use collection_id instead of unit_id for Collection ID

### DIFF
--- a/app/views/catalog/_show_actions_box_default.html.erb
+++ b/app/views/catalog/_show_actions_box_default.html.erb
@@ -1,0 +1,27 @@
+<div class='al-show-actions-box'>
+  <div class="al-actions-box-container">
+    <% if document.collection_unitid || document.containers.present? %>
+      <div class='al-collection-id'>
+        <% if document.collection_unitid %>
+          <%= t(:'arclight.views.show.collection_id', id: document.collection_unitid) %>
+        <% end %>
+
+        <% if document.collection_unitid && document.containers.present? %>
+          <span> | </span>
+        <% end %>
+
+        <% if document.containers.present? %>
+          <span><%= document.containers.join(', ') %></span>
+        <% end %>
+      </div>
+    <% end %>
+    <div class='al-show-actions-box-options d-flex'>
+      <%= render partial: 'arclight/requests', locals: { document: document } %>
+      <div class='al-show-actions-box-bookmarks flex-md-fill'>
+        <%= render partial: 'catalog/bookmark_control', locals: { document: document } %>
+      </div>
+    </div>
+  </div>
+
+  <%= render document.downloads %>
+</div>


### PR DESCRIPTION
Box in the top right was using the `unit_id` value instead of the `collection_id` value.