### PR TITLE
fix: reset search session when coming from bento search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -10,6 +10,8 @@ class CatalogController < ApplicationController
   include Arclight::Catalog
   include Arclight::FieldConfigHelpers
 
+  before_action :reset_search_session, only: [:show]
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     if ENV["ZK_HOST"].present? && ENV["SOLR_COLLECTION"].present?
@@ -406,5 +408,13 @@ class CatalogController < ApplicationController
     # Compact index view
     config.view.compact
     config.view.compact.partials = %i[arclight_index_compact]
+  end
+
+  def reset_search_session
+    referrer = request.referrer
+    if referrer.present? && referrer.include?("/search?q=")
+      Rails.logger.info "Referrer is #{referrer}, resetting search session."
+      session[:search] = {}
+    end
   end
 end


### PR DESCRIPTION
Normally, going back to search index page will reset the search session. Going directly from a finding aid record to a new bento search circumvents this reset that Blacklight/Arclight performs because it's outside it's provided functionality.

This change checks if the referrer is the bento search before displaying the finding aid record to reset the search session.