### PR TITLE
BLAC-464: Apply NLA colours to blacklight_range_limit

### DIFF
--- a/app/assets/javascripts/blacklight/blacklight.js
+++ b/app/assets/javascripts/blacklight/blacklight.js
@@ -505,3 +505,11 @@ Blacklight.onLoad(function () {
   Blacklight.doSearchContextBehavior();
 });
 
+$(function() {
+  $('.blrl-plot-config').data('plot-config', {
+    selection: { color: '#46474A' },
+    colors: ['#ffffff'],
+    series: { lines: { fillColor: 'rgba(112,57,150, 0.8)' }},
+    grid: { color: '#677078', tickColor: '#f4f5f6', borderWidth: 1 }
+  });
+});

--- a/app/assets/stylesheets/nla/_facets.scss
+++ b/app/assets/stylesheets/nla/_facets.scss
@@ -73,4 +73,23 @@
       }
     }
   }
+    
+  .slider_js {
+    .slider-handle {
+      background-image: none;
+      background-color: color("white");
+      border: 2px solid color("purple");
+      opacity: 1;
+      
+      &:active,
+      &:hover {
+        background-color: color("purple");
+      }
+    }
+    
+    .slider-selection {
+      background-image: none;
+      background: color("light-purple") !important;
+    }
+  }
 }


### PR DESCRIPTION
For some reason, even before these changes the year range chart isn't appearing in my local environment. I've applied the same changes as in blacklight, but haven't been able to test properly.