### PR TITLE
feat: restyle titles and silence deprecation warnings

### DIFF
--- a/app/assets/stylesheets/nla/_record.scss
+++ b/app/assets/stylesheets/nla/_record.scss
@@ -48,6 +48,30 @@ li.al-collection-context .al-online-content-icon svg,
   }
 }
 
+.al-grouped-title-bar {
+  h3 a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.grouped-documents {
+  .document {
+    .documentHeader {
+      h4 a {
+        text-decoration: none;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+}
+
 .document {
   h1.media svg,
   .breadcrumb .media svg,
@@ -62,5 +86,15 @@ li.al-collection-context .al-online-content-icon svg,
   .al-document-container.text-muted {
     color: color("gray-medium-light") !important;
     font-size: 0.875rem;
+  }
+}
+
+.document-title-heading {
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,12 @@ if %w[development test].include? ENV["RAILS_ENV"]
   Dotenv::Railtie.load
 end
 
+if %w[staging production].include? ENV["RAILS_ENV"]
+  # Silence deprecation warnings in staging/production
+  require "deprecation"
+  Deprecation.default_deprecation_behavior = :silence
+end
+
 module NlaArclight
   VERSION = "2.2.1"
 


### PR DESCRIPTION
Removes underlines and numbering from title links.

Also added some code to silence the deprecation warnings in staging/prod so they don't clutter up the logs.