### PR TITLE
fix: display range limit chart on apply

### DIFF
--- a/app/components/blacklight_range_limit/range_facet_component.html.erb
+++ b/app/components/blacklight_range_limit/range_facet_component.html.erb
@@ -1,0 +1,56 @@
+<%= render(@layout.new(facet_field: @facet_field)) do |component| %>
+  <% component.label do %>
+    <%= @facet_field.label %>
+  <% end %>
+
+  <% component.body do %>
+    <div class="limit_content range_limit <%= @facet_field.key %>-config blrl-plot-config">
+      <% if @facet_field.selected_range_facet_item %>
+        <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field, facet_items: [@facet_field.selected_range_facet_item], classes: ['current']) %>
+      <% end %>
+
+      <!-- no results profile if missing is selected -->
+      <% unless @facet_field.missing_selected? %>
+        <!-- you can hide this if you want, but it has to be on page if you want
+             JS slider and calculated facets to show up, JS sniffs it. -->
+        <div class="profile">
+          <% if (min = @facet_field.min) &&
+                (max = @facet_field.max) %>
+
+            <% if range_config[:segments] != false %>
+              <div class="distribution subsection <%= 'chart_js' unless range_config[:chart_js] == false %>">
+                <!-- if  we already fetched segments from solr, display them
+                     here. Otherwise, display a link to fetch them, which JS
+                     will AJAX fetch.  -->
+                <% if @facet_field.range_queries.any? %>
+                  <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field) %>
+                <% else %>
+                  <%= link_to(t('blacklight.range_limit.view_distribution'), range_limit_url(range_start: min, range_end: max), class: "load_distribution") %>
+                <% end %>
+              </div>
+            <% end %>
+            <p class="range subsection <%= "slider_js" unless range_config[:slider_js] == false %>">
+              <%= t('blacklight.range_limit.results_range_html', min: min, max: max) %>
+            </p>
+          <% end %>
+        </div>
+
+        <%= render BlacklightRangeLimit::RangeFormComponent.new(facet_field: @facet_field, classes: @classes) %>
+
+        <%= more_link(key: @facet_field.key, label: @facet_field.label) unless @facet_field.in_modal? %>
+
+        <% if @facet_field.missing_facet_item && !request.xhr? %>
+          <%= render BlacklightRangeLimit::RangeSegmentsComponent.new(facet_field: @facet_field, facet_items: [@facet_field.missing_facet_item], classes: ['missing', 'subsection']) %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+<script>
+  $('.blrl-plot-config').data('plot-config', {
+    selection: { color: '#46474A' },
+    colors: ['#ffffff'],
+    series: { lines: { fillColor: 'rgba(112,57,150, 0.8)' }},
+    grid: { color: '#677078', tickColor: '#f4f5f6', borderWidth: 1 }
+  });
+</script>

--- a/app/components/blacklight_range_limit/range_form_component.html.erb
+++ b/app/components/blacklight_range_limit/range_form_component.html.erb
@@ -1,0 +1,12 @@
+<%= form_tag search_action_path, method: :get, class: [@classes[:form], "range_#{@facet_field.key} d-flex justify-content-center"].join(' ') do %>
+  <%= render hidden_search_state %>
+  <%= hidden_field_tag :group, false %>
+  <div class="input-group input-group-sm mb-3 flex-nowrap range-limit-input-group">
+    <%= render_range_input(:begin, begin_label) %>
+    <%= render_range_input(:end, end_label) %>
+    <div class="input-group-append visually-hidden">
+      <%= submit_tag t('blacklight.range_limit.submit_limit'), class: @classes[:submit], name: nil %>
+    </div>
+    <%= submit_tag t('blacklight.range_limit.submit_limit'), class: @classes[:submit] + " sr-only", "aria-hidden": "true", name: nil %>
+  </div>
+<% end %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -3,7 +3,7 @@
 %>
 <%= form_tag search_action_url, method: :get, class: 'search-query-form pr-0', role: 'search' do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8).merge(f: (search_state.params_for_search[:f] || {}).except(:collection_sim))) %>
-  <%= hidden_field_tag :group, true %>
+
   <div class="d-md-flex">
     <%= render 'catalog/within_collection_dropdown' %>
 


### PR DESCRIPTION
Range limit chart only renders correctly when results are not grouped, but the search field was defaulting all results to grouped.

Overrode templates to fix the styling and force the search results display not to be grouped when clicking "Apply".