### PR TITLE
chore: pull in patron Keycloak changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 2f06439c9a3a23d09f671eef02d974ba96a9deed
+  revision: d5c1b64dfc034d60c1eb5c12f25523c491160414
   branch: main
   specs:
     nla-blacklight_common (0.1.8)
@@ -517,7 +517,7 @@ GEM
     stringio (3.0.8)
     strong_migrations (1.6.3)
       activerecord (>= 5.2)
-    thor (1.2.2)
+    thor (1.3.0)
     tilt (2.3.0)
     timeout (0.4.0)
     traject (3.8.1)


### PR DESCRIPTION
Changes are feature flagged behind `KC_PATRON_REALM` environment variable, so should display and function using UserReg until Keycloak patron realm configuration is configured.