### PR TITLE
fix: pin blacklight version to avoid view component upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 gem "arclight", "~> 0.5", "< 1.0"
-gem "blacklight", "~> 7.32", "< 8"
+gem "blacklight", "7.33.1"
 gem "blacklight_range_limit", "~> 8.2"
 gem "rsolr", ">= 1.0", "< 3"
 gem "bootstrap", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    blacklight (7.34.0)
+    blacklight (7.33.1)
       deprecation
       globalid
       hashdiff
@@ -128,7 +128,7 @@ GEM
       kaminari (>= 0.15)
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7.1)
-      view_component (>= 2.66, < 4)
+      view_component (~> 2.66)
     blacklight-locale_picker (1.0.0)
       rails (>= 5.2.3, < 7.1)
     blacklight_range_limit (8.3.0)
@@ -551,7 +551,7 @@ GEM
     unf_ext (0.0.8.2)
     unicode-display_width (2.5.0)
     version_gem (1.1.3)
-    view_component (3.6.0)
+    view_component (2.82.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -607,7 +607,7 @@ DEPENDENCIES
   awesome_print
   better_errors
   binding_of_caller
-  blacklight (~> 7.32, < 8)
+  blacklight (= 7.33.1)
   blacklight-locale_picker
   blacklight_range_limit (~> 8.2)
   bootsnap


### PR DESCRIPTION
Blacklight recently published a new 7.34 minor version that back ports some changes from version 8. This pulls in a more recent 3.x version of `view_component` that has changes that break the PaginationComponent used in arclight.

This change pins blacklight to version 7.33.1. Version 1.0 of Arclight is based on Blacklight 8, so it supports the more recent version of `view_component` that Blacklight 8 uses.