### PR TITLE
fix: single document search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem "blacklight-locale_picker"
 gem "zk", "~> 1.10"
 gem "nokogiri", ">= 1.13.9"
 
-gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "feat/upgrade"
+gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "fix/single-document-search"
 gem "blacklight_range_limit", git: "https://github.com/nla/blacklight_range_limit", branch: "main"
 # For local development, comment out above ⤴️ and uncomment below ⤵️
 # gem "nla-blacklight_common", path: "../nla-blacklight_common"

--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem "blacklight-locale_picker"
 gem "zk", "~> 1.10"
 gem "nokogiri", ">= 1.13.9"
 
-gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "fix/single-document-search"
+gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "main"
 gem "blacklight_range_limit", git: "https://github.com/nla/blacklight_range_limit", branch: "main"
 # For local development, comment out above ⤴️ and uncomment below ⤵️
 # gem "nla-blacklight_common", path: "../nla-blacklight_common"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 1d7fe29bdb08fb13b02ab33f69a87340ac79b277
-  branch: feat/upgrade
+  revision: 5d4fb5d0142ac8e1b3a3741a4f2b6569c9cab0ad
+  branch: fix/single-document-search
   specs:
     nla-blacklight_common (0.1.12)
       activerecord-session_store (~> 2.0)
@@ -156,7 +156,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cgi (0.4.1)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crack (0.4.5)
       rexml
@@ -313,7 +313,7 @@ GEM
     mini_histogram (0.3.1)
     mini_mime (1.1.5)
     minitar (0.9)
-    minitest (5.21.1)
+    minitest (5.21.2)
     msgpack (1.7.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 5d4fb5d0142ac8e1b3a3741a4f2b6569c9cab0ad
-  branch: fix/single-document-search
+  revision: ed0d71bcdcccc599be3fc00a6970ca368c93e8d4
+  branch: main
   specs:
     nla-blacklight_common (0.1.12)
       activerecord-session_store (~> 2.0)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "blacklight/solr_cloud/repository"
+require "nla/solr_cloud/repository"
 
 # Blacklight controller that handles searches and document requests
 class CatalogController < ApplicationController
@@ -13,7 +13,7 @@ class CatalogController < ApplicationController
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     if ENV["ZK_HOST"].present? && ENV["SOLR_COLLECTION"].present?
-      config.repository_class = Blacklight::SolrCloud::Repository
+      config.repository_class = Nla::SolrCloud::Repository
     end
     #
     ## Class for converting Blacklight's url parameters to into request parameters for the search index
@@ -39,7 +39,15 @@ class CatalogController < ApplicationController
     config.highlight_field = "text"
 
     # solr path which will be added to solr base url before the other solr params.
-    # config.solr_path = 'select'
+    config.solr_path = "select"
+    config.document_solr_path = "select"
+
+    # solr parameters to send on single-document requests to Solr.
+    # The "q" param is formatted in Blacklight::SolrCloud::Repository.find to search the "id" field.
+    config.document_unique_id_param = "q"
+    # These are sent by default to ensure all document fields are returned.
+    # Facets, spellcheck and response header are omitted, since they're not needed.
+    config.default_document_solr_params = {fl: "*", facet: "false", spellcheck: "false", omitHeader: "true"}
 
     # items to show per page, each number in the array represent another option to choose from.
     # config.per_page = [10,20,50,100]


### PR DESCRIPTION
Depends on https://github.com/nla/nla-blacklight_common/pull/59

This pulls in those changes from the common lib and configures Blacklight to use /select and pass some extra default params to avoid returning the response header, spellcheck and facets.