### PR TITLE
feat: implement email 2fa alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem "blacklight-locale_picker"
 gem "zk", "~> 1.10"
 gem "nokogiri", ">= 1.13.9"
 
-gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", tag: "0.2.0"
+gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "main"
 gem "blacklight_range_limit", git: "https://github.com/nla/blacklight_range_limit", branch: "main"
 # For local development, comment out above ⤴️ and uncomment below ⤵️
 # gem "nla-blacklight_common", path: "../nla-blacklight_common"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 91916c3dda4306a9279759a1a23f043e311228a3
-  tag: 0.2.0
+  revision: 09310ddda34b7b5c0a8a20d1268233551bbfa67e
+  branch: main
   specs:
     nla-blacklight_common (0.2.0)
       activerecord-session_store (~> 2.0)
@@ -105,7 +105,7 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
-    annotaterb (4.6.0)
+    annotaterb (4.7.0)
     anyway_config (2.5.4)
       ruby-next-core (>= 0.14.0)
     arclight (1.0.1)
@@ -123,6 +123,7 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
+    bigdecimal (3.1.7)
     bindata (2.5.0)
     bindex (0.8.1)
     binding_of_caller (1.0.0)
@@ -186,7 +187,7 @@ GEM
       rake (> 10, < 14)
       ruby-statistics (>= 2.1)
       thor (>= 0.19, < 2)
-    devise (4.9.3)
+    devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -250,7 +251,7 @@ GEM
     irb (1.10.0)
       rdoc
       reline (>= 0.3.8)
-    jbuilder (2.11.5)
+    jbuilder (2.12.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.0)
@@ -306,14 +307,15 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     memory_profiler (1.0.1)
-    method_source (1.0.0)
+    method_source (1.1.0)
     mini_histogram (0.3.1)
     mini_mime (1.1.5)
     minitar (0.9)
-    minitest (5.22.2)
+    minitest (5.22.3)
     msgpack (1.7.2)
     multi_json (1.15.0)
-    multi_xml (0.6.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     mysql2 (0.5.5)
     net-http (0.4.1)
       uri
@@ -324,12 +326,12 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0.1)
+    net-smtp (0.5.0)
       net-protocol
-    nio4r (2.7.0)
-    nokogiri (1.16.2-arm64-darwin)
+    nio4r (2.7.1)
+    nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-linux)
+    nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -366,7 +368,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
-    rack (2.2.8.1)
+    rack (2.2.9)
     rack-mini-profiler (3.1.1)
       rack (>= 1.2.0)
     rack-protection (3.2.0)
@@ -407,7 +409,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.2.1)
     rdoc (6.6.0)
       psych (>= 4.0.0)
     redis (5.0.8)
@@ -425,7 +427,7 @@ GEM
     retriable (3.1.2)
     rexml (3.2.6)
     rouge (4.2.0)
-    rsolr (2.5.0)
+    rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
     rspec-core (3.12.2)
@@ -558,8 +560,8 @@ GEM
     unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    version_gem (1.1.3)
-    view_component (3.11.0)
+    version_gem (1.1.4)
+    view_component (3.12.1)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -671,4 +673,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.5.6
+   2.5.7

--- a/app/components/arclight/header_component.html.erb
+++ b/app/components/arclight/header_component.html.erb
@@ -2,6 +2,7 @@
   <%= top_bar %>
   <div class="<%= helpers.container_classes %>">
     <%= render GlobalMessageComponent.new %>
+    <%= render "shared/email_2fa_alert" %>
   </div>
   <%= search_bar %>
 </header>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,8 @@ class ApplicationController < ActionController::Base
 
   # Some parts of the application are not suitable for storing the location
   def is_a_storable_controller_action?
-    !is_a?(Users::SessionsController) && # ignore login requests
+    !is_a?(Email2faAlertController) && # ignore email 2fa alert requests
+      !is_a?(Users::SessionsController) && # ignore login requests
       !is_a?(Users::OmniauthCallbacksController) # ignore login requests to Keycloak
   end
 

--- a/app/javascript/controllers/email_2fa_alert_controller.js
+++ b/app/javascript/controllers/email_2fa_alert_controller.js
@@ -1,0 +1,42 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="email-2fa-alert"
+export default class extends Controller {
+  static values = {
+    url: String,
+    dismissUrl: String
+  }
+
+  connect() {
+    this.fetchContent()
+  }
+
+  fetchContent() {
+    fetch(this.urlValue)
+    .then(response => {
+      if (response.ok) {
+        response.text().then((text) => this.element.innerHTML = text)
+      } else {
+        this.element.innerHTML = "An error occurred."
+      }
+    })
+    .catch((_error) => {
+      this.element.innerHTML = "An error occurred."
+    })
+  }
+
+  dismiss() {
+    fetch(this.dismissUrlValue)
+    .then(response => {
+      if (response.ok) {
+        console.log("dismissed")
+        this.fetchContent()
+      } else {
+        this.element.innerHTML = "An error occurred."
+      }
+    })
+    .catch((_error) => {
+      this.element.innerHTML = "An error occurred."
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import Email2faAlertController from "./email_2fa_alert_controller"
+application.register("email-2fa-alert", Email2faAlertController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,74 @@
+# == Route Map
+#
+#                                   Prefix Verb     URI Pattern                                           Controller#Action
+#                               blacklight          /finding-aids                                         Blacklight::Engine
+#                          arclight_engine          /finding-aids                                         Arclight::Engine
+#               yabeda_prometheus_exporter          /finding-aids/metrics                                 Yabeda::Prometheus::Exporter
+#                           search_catalog GET|POST /finding-aids/catalog(.:format)                       catalog#index
+#                  advanced_search_catalog GET      /finding-aids/catalog/advanced(.:format)              catalog#advanced_search
+#                       page_links_catalog GET      /finding-aids/catalog/page_links(.:format)            catalog#page_links
+#                            track_catalog POST     /finding-aids/catalog/:id/track(.:format)             catalog#track
+#                              raw_catalog GET      /finding-aids/catalog/:id/raw(.:format)               catalog#raw {:format=>"json"}
+#                       opensearch_catalog GET      /finding-aids/catalog/opensearch(.:format)            catalog#opensearch
+#                    suggest_index_catalog GET      /finding-aids/catalog/suggest(.:format)               catalog#suggest
+#                            facet_catalog GET      /finding-aids/catalog/facet/:id(.:format)             catalog#facet
+#                      range_limit_catalog GET      /finding-aids/catalog/range_limit(.:format)           catalog#range_limit
+#                                          GET      /finding-aids/catalog/range_limit_panel/:id(.:format) catalog#range_limit_panel
+#                  hierarchy_solr_document GET      /finding-aids/catalog/:id/hierarchy(.:format)         catalog#hierarchy
+#                      email_solr_document GET|POST /finding-aids/catalog/:id/email(.:format)             catalog#email
+#                        sms_solr_document GET|POST /finding-aids/catalog/:id/sms(.:format)               catalog#sms
+#                   citation_solr_document GET      /finding-aids/catalog/:id/citation(.:format)          catalog#citation
+#                     email_solr_documents GET|POST /finding-aids/catalog/email(.:format)                 catalog#email
+#                       sms_solr_documents GET|POST /finding-aids/catalog/sms(.:format)                   catalog#sms
+#                  citation_solr_documents GET      /finding-aids/catalog/citation(.:format)              catalog#citation
+#                            solr_document GET      /finding-aids/catalog/:id(.:format)                   catalog#show
+#                           email_bookmark GET|POST /finding-aids/bookmarks/:id/email(.:format)           bookmarks#email
+#                             sms_bookmark GET|POST /finding-aids/bookmarks/:id/sms(.:format)             bookmarks#sms
+#                        citation_bookmark GET      /finding-aids/bookmarks/:id/citation(.:format)        bookmarks#citation
+#                          email_bookmarks GET|POST /finding-aids/bookmarks/email(.:format)               bookmarks#email
+#                            sms_bookmarks GET|POST /finding-aids/bookmarks/sms(.:format)                 bookmarks#sms
+#                       citation_bookmarks GET      /finding-aids/bookmarks/citation(.:format)            bookmarks#citation
+#                          clear_bookmarks DELETE   /finding-aids/bookmarks/clear(.:format)               bookmarks#clear
+#                                bookmarks GET      /finding-aids/bookmarks(.:format)                     bookmarks#index
+#                                          POST     /finding-aids/bookmarks(.:format)                     bookmarks#create
+#                             new_bookmark GET      /finding-aids/bookmarks/new(.:format)                 bookmarks#new
+#                            edit_bookmark GET      /finding-aids/bookmarks/:id/edit(.:format)            bookmarks#edit
+#                                 bookmark GET      /finding-aids/bookmarks/:id(.:format)                 bookmarks#show
+#                                          PATCH    /finding-aids/bookmarks/:id(.:format)                 bookmarks#update
+#                                          PUT      /finding-aids/bookmarks/:id(.:format)                 bookmarks#update
+#                                          DELETE   /finding-aids/bookmarks/:id(.:format)                 bookmarks#destroy
+#                         email_2fa_enable GET      /finding-aids/email_2fa/enable(.:format)              email2fa#enable
+#                        email_2fa_disable GET      /finding-aids/email_2fa/disable(.:format)             email2fa#disable
+#                          email_2fa_alert GET      /finding-aids/email_2fa/alert(.:format)               email2fa_alert#show
+#                  email_2fa_alert_dismiss GET      /finding-aids/email_2fa/alert/dismiss(.:format)       email2fa_alert#dismiss
+#                                     root GET      /finding-aids(.:format)                               catalog#index {:f=>{:level=>["Collection"], :repository=>["National Library of Australia"]}}
+#                                          GET      /                                                     redirect(301, /finding-aids)
+# user_catalogue_patron_omniauth_authorize GET|POST /users/auth/catalogue_patron(.:format)                users/omniauth_callbacks#passthru
+#  user_catalogue_patron_omniauth_callback GET|POST /users/auth/catalogue_patron/callback(.:format)       users/omniauth_callbacks#catalogue_patron
+#    user_catalogue_sol_omniauth_authorize GET|POST /users/auth/catalogue_sol(.:format)                   users/omniauth_callbacks#passthru
+#     user_catalogue_sol_omniauth_callback GET|POST /users/auth/catalogue_sol/callback(.:format)          users/omniauth_callbacks#catalogue_sol
+#    user_catalogue_spl_omniauth_authorize GET|POST /users/auth/catalogue_spl(.:format)                   users/omniauth_callbacks#passthru
+#     user_catalogue_spl_omniauth_callback GET|POST /users/auth/catalogue_spl/callback(.:format)          users/omniauth_callbacks#catalogue_spl
+# user_catalogue_shared_omniauth_authorize GET|POST /users/auth/catalogue_shared(.:format)                users/omniauth_callbacks#passthru
+#  user_catalogue_shared_omniauth_callback GET|POST /users/auth/catalogue_shared/callback(.:format)       users/omniauth_callbacks#catalogue_shared
+#                         new_user_session GET      /sign_in(.:format)                                    users/sessions#new
+#                     destroy_user_session DELETE   /sign_out(.:format)                                   users/sessions#destroy
+#                                   logout GET      /logout(.:format)                                     users/sessions#destroy
+#                  expired_keycloak_logout GET      /expired_keycloak_logout(.:format)                    users/sessions#expired_keycloak_logout
+#                       backchannel_logout POST     /backchannel_logout(.:format)                         users/sessions#backchannel_logout
+#         turbo_recede_historical_location GET      /recede_historical_location(.:format)                 turbo/native/navigation#recede
+#         turbo_resume_historical_location GET      /resume_historical_location(.:format)                 turbo/native/navigation#resume
+#        turbo_refresh_historical_location GET      /refresh_historical_location(.:format)                turbo/native/navigation#refresh
+#
+# Routes for Blacklight::Engine:
+#       search_history GET    /search_history(.:format)       search_history#index
+# clear_search_history DELETE /search_history/clear(.:format) search_history#clear
+#
+# Routes for Arclight::Engine:
+#  collections GET  /collections(.:format)      catalog#index {:f=>{:level=>["Collection"]}}
+# repositories GET  /repositories(.:format)     arclight/repositories#index
+#   repository GET  /repositories/:id(.:format) arclight/repositories#show
+
 Rails.application.routes.draw do
   scope(path: "/finding-aids") do
     mount Blacklight::Engine => "/"
@@ -8,6 +79,7 @@ Rails.application.routes.draw do
     concern :exportable, Blacklight::Routes::Exportable.new
     concern :hierarchy, Arclight::Routes::Hierarchy.new
     concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
+    concern :email2fa, Nla::BlacklightCommon::Routes::Email2fa.new
 
     resource :catalog, only: [:index], as: "catalog", path: "/catalog", controller: "catalog" do
       concerns :searchable
@@ -26,6 +98,8 @@ Rails.application.routes.draw do
         delete "clear"
       end
     end
+
+    concerns :email2fa
 
     # Show repostories with information about each
     # root to: "arclight/repositories#index"

--- a/db/patrons_schema.rb
+++ b/db/patrons_schema.rb
@@ -12,35 +12,35 @@
 
 ActiveRecord::Schema[7.0].define(version: 2023_04_26_043927) do
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_accounts_on_user_id"
   end
 
   create_table "sessions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "session_id", null: false
-    t.text "data"
     t.datetime "created_at", null: false
+    t.text "data"
+    t.string "session_id", null: false
     t.datetime "updated_at", null: false
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "folio_id"
-    t.bigint "patron_id"
-    t.bigint "voyager_id"
-    t.string "name_given"
-    t.string "name_family"
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.string "folio_id"
+    t.string "name_family"
+    t.string "name_given"
+    t.bigint "patron_id"
     t.string "provider"
-    t.string "uid"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "active", default: true, null: false
     t.string "session_token"
+    t.string "uid"
+    t.datetime "updated_at", null: false
+    t.bigint "voyager_id"
     t.index ["folio_id"], name: "index_users_on_folio_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,23 +12,23 @@
 
 ActiveRecord::Schema[7.0].define(version: 2022_09_27_060510) do
   create_table "bookmarks", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "user_type"
+    t.datetime "created_at", precision: nil, null: false
     t.string "document_id"
     t.string "document_type"
     t.binary "title"
-    t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id", null: false
+    t.string "user_type"
     t.index ["document_id"], name: "index_bookmarks_on_document_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
   create_table "searches", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", precision: nil, null: false
     t.binary "query_params"
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"
     t.string "user_type"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 


### PR DESCRIPTION
Implementation of the alert shown to encourage users to turn on email 2FA. The mechanism to enable/disable email 2FA is implemented in the catalogue, so it resides in Blacklight, not Arclight.