### PR TITLE
BLAC-685: concat extents information

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -366,10 +366,7 @@ class CatalogController < ApplicationController
     config.add_component_field "accruals", field: "accruals_html_tesm", helper_method: :render_html_tags
     config.add_component_field "phystech", field: "phystech_html_tesm", helper_method: :render_html_tags
     config.add_component_field "physloc", field: "physloc_html_tesm", helper_method: :render_html_tags
-    config.add_component_field "physfacet", field: "physdesc_facet_ssi", helper_method: :render_html_tags
-    config.add_component_field "physquantity", field: "physdesc_quantity_ssi", helper_method: :render_html_tags
-    config.add_component_field "physunittype", field: "physdesc_unittype_ssi", helper_method: :render_html_tags
-    config.add_component_field "physdimensions", field: "physdesc_dimensions_ssi", helper_method: :render_html_tags
+    config.add_component_field "extentsinfo", field: "extents_information", accessor: :extents_information, helper_method: :render_html_tags
 
     # Component Show Page - Indexed Terms Section
     config.add_component_indexed_terms_field "access_subjects", field: "access_subjects_ssim", link_to_facet: true, separator_options: {

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -12,6 +12,24 @@ class SolrDocument
     [self["level_ssm"]&.join(" "), self["unitid_ssm"]&.join(" ")].compact.join(" ")
   end
 
+  def extents_information
+    quantity_unittype = [
+      self["physdesc_quantity_ssi"],
+      self["physdesc_unittype_ssi"]
+    ].compact.join(" ")
+
+    dimensions_facet = [
+      self["physdesc_dimensions_ssi"],
+      self["physdesc_facet_ssi"]
+    ].compact.join(", ")
+
+    if quantity_unittype.blank?
+      dimensions_facet
+    else
+      [quantity_unittype, dimensions_facet].compact.join(", ")
+    end
+  end
+
   # self.unique_key = 'id'
 
   # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -22,10 +22,7 @@ en:
         phystech: Physical / technical requirements
         physloc: Physical location
         descrules: Rules or conventions
-        physfacet: Format
-        physquantity: Quantity
-        physunittype: Physical unit type
-        physdimensions: Physical dimensions
+        extentsinfo: Extent information
 
         relatedmaterial: Related material
         separatedmaterial: Separated material

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -54,4 +54,63 @@ RSpec.describe SolrDocument do
       end
     end
   end
+
+  describe "#extents_information" do
+    context "when quantity, unit type, dimensions, and facet are present" do
+      subject(:extents_information_value) do
+        document = described_class.new(
+          physdesc_quantity_ssi: ["1"],
+          physdesc_unittype_ssi: ["item"],
+          physdesc_dimensions_ssi: ["Unbranded"],
+          physdesc_facet_ssi: ["Data CD (any content on recordable CD-R)"]
+        )
+        document.extents_information
+      end
+
+      it "is formatted as: quantity + unittype, dimension, facet" do
+        expect(extents_information_value).to eq "1 item, Unbranded, Data CD (any content on recordable CD-R)"
+      end
+    end
+
+    context "when quantity is nil" do
+      subject(:extents_information_value) do
+        document = described_class.new(
+          physdesc_unittype_ssi: ["item"],
+          physdesc_dimensions_ssi: ["Unbranded"],
+          physdesc_facet_ssi: ["Data CD (any content on recordable CD-R)"]
+        )
+        document.extents_information
+      end
+
+      it "returns unittype, dimension, facet" do
+        expect(extents_information_value).to eq "item, Unbranded, Data CD (any content on recordable CD-R)"
+      end
+    end
+
+    context "when quantity and unittype are nil" do
+      subject(:extents_information_value) do
+        document = described_class.new(
+          physdesc_dimensions_ssi: ["Unbranded"],
+          physdesc_facet_ssi: ["Data CD (any content on recordable CD-R)"]
+        )
+        document.extents_information
+      end
+
+      it "returns only dimensions and facet" do
+        expect(extents_information_value).to eq "Unbranded, Data CD (any content on recordable CD-R)"
+      end
+    end
+
+    context "when all fields are nil" do
+      subject(:extents_information_value) do
+        document = described_class.new
+
+        document.extents_information
+      end
+
+      it "returns an empty string" do
+        expect(extents_information_value).to eq ""
+      end
+    end
+  end
 end


### PR DESCRIPTION
Concatenate extents fields into one "Extents information" field to be inline with trove.