### PR TITLE
fix: return nil extent information to avoid displaying an empty metadata field

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -43,11 +43,13 @@ class SolrDocument
       physdesc_facet
     ].compact.join(", ")
 
-    if quantity_unittype.blank?
+    extent_info = if quantity_unittype.blank?
       dimensions_facet
     else
       [quantity_unittype, dimensions_facet].compact.join(", ")
     end
+
+    extent_info.presence
   end
 
   def extract_notes_by_header(header)

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe SolrDocument do
         document.extents_information
       end
 
-      it "returns an empty string" do
-        expect(extents_information_value).to eq ""
+      it "returns nil" do
+        expect(extents_information_value).to be_nil
       end
     end
   end


### PR DESCRIPTION
When returning an empty string, the metadata heading still displays without any text. Returning `nil` will tell Arclight not to display anything.