### PR TITLE
fix: formatting resiliency

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -100,7 +100,9 @@ class SolrDocument
     if value.start_with?("<")
       value
     else
-      ActionController::Base.helpers.content_tag(:p, value)
+      # rubocop:disable Rails/OutputSafety
+      ActionController::Base.helpers.content_tag(:p, value.html_safe)
+      # rubocop:enable Rails/OutputSafety
     end
   end
 end

--- a/app/presenters/rendering/chronlist.rb
+++ b/app/presenters/rendering/chronlist.rb
@@ -22,7 +22,7 @@ module Rendering
 
       Nokogiri::HTML::Builder.with(fragment) do |doc|
         if values["head"].present?
-          doc.h3 {
+          doc.h4 {
             doc.text values["head"]
           }
         end

--- a/app/presenters/subnotes_presenter.rb
+++ b/app/presenters/subnotes_presenter.rb
@@ -16,7 +16,6 @@ class SubnotesPresenter < Blacklight::FieldPresenter
       if valid_json?(value)
         render_subnote(value)
       else
-        # Otherwise, render it normally
         value
       end
     end
@@ -36,16 +35,22 @@ class SubnotesPresenter < Blacklight::FieldPresenter
     # rendered in order, since the generated HTML from each subnote is concatenated together to
     # form the whole note.
 
-    if subnote_value.key? TABLE_ELEMENT
-      rendered_subnote << Blacklight::Rendering::Pipeline.new(subnote_value[TABLE_ELEMENT], field_config, document, view_context, [Rendering::Table], options).render
-    end
+    begin
+      if subnote_value.key? TABLE_ELEMENT
+        rendered_subnote << Blacklight::Rendering::Pipeline.new(subnote_value[TABLE_ELEMENT], field_config, document, view_context, [Rendering::Table], options).render
+      end
 
-    if subnote_value.key? CHRONLIST_ELEMENT
-      rendered_subnote << Blacklight::Rendering::Pipeline.new(subnote_value[CHRONLIST_ELEMENT], field_config, document, view_context, [Rendering::Chronlist], options).render
-    end
+      if subnote_value.key? CHRONLIST_ELEMENT
+        rendered_subnote << Blacklight::Rendering::Pipeline.new(subnote_value[CHRONLIST_ELEMENT], field_config, document, view_context, [Rendering::Chronlist], options).render
+      end
 
-    if subnote_value.key? BIBREF_ELEMENT
-      rendered_subnote << Blacklight::Rendering::Pipeline.new(subnote_value[BIBREF_ELEMENT], field_config, document, view_context, [Rendering::Bibref], options).render
+      if subnote_value.key? BIBREF_ELEMENT
+        rendered_subnote << Blacklight::Rendering::Pipeline.new(subnote_value[BIBREF_ELEMENT], field_config, document, view_context, [Rendering::Bibref], options).render
+      end
+    rescue
+      # If there's an error rendering a subnote, render the original value instead to avoid
+      # breaking the whole page.
+      subnote_value << value
     end
 
     # everything else that's not a known subnote element will not be rendered

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe SolrDocument do
       end
     end
 
-    context "when note already contains HTML tags" do
+    context "when note starts with an HTML tag" do
       subject(:notes_value) do
         document.extract_notes_by_header("references")
       end
@@ -206,6 +206,22 @@ RSpec.describe SolrDocument do
 
       it "doesn't wrap the content again" do
         expect(notes_value).to eq ["<p>Testing</p>"]
+      end
+    end
+
+    context "when note doesn't start with an HTML tag and contains HTML" do
+      subject(:notes_value) do
+        document.extract_notes_by_header("references")
+      end
+
+      let(:document) {
+        described_class.new(
+          note_json_ssm: ["{\"head\":\"References\",\"p\":\"Testing <em>HTML</em> inside a paragraph.\",\"audience\":\"internal\"}"]
+        )
+      }
+
+      it "wraps the note in a paragraph and doesn't escape the existing markup" do
+        expect(notes_value).to eq ["<p>Testing <em>HTML</em> inside a paragraph.</p>"]
       end
     end
 

--- a/spec/presenters/rendering/chronlist_spec.rb
+++ b/spec/presenters/rendering/chronlist_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Rendering::Chronlist do
       let(:note) { JSON.parse(IO.read("spec/files/notes/chronlist_no-header_eventgrp.json")) }
 
       it "renders the chronlist with just the date" do
-        expect(rendered).to have_css("h3", text: "Honours and Awards")
+        expect(rendered).to have_css("h4", text: "Honours and Awards")
         expect(rendered).to have_table(class: %w[table-light table-responsive table-striped table-hover])
         expect(rendered).to have_css("thead.table-purple")
         expect(rendered).to have_css("tbody.table-group-divider")


### PR DESCRIPTION
Added a catch all exception handler to prevent the page crashing in case there is a formatting edge case that can't be handled by the subnotes renderers that throws an exception.

Also fixed up encoding of HTML markup in paragraphs and made the `chronlist` heading level consistent with the `table` heading.